### PR TITLE
Fix optgroups.

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -429,7 +429,7 @@ class Chosen extends AbstractChosen
       else
         item.selected = true
 
-        @source.get_option_element(item.array_index).selected = true
+        @source.get_option_element(item.array_index - item.group_offset).selected = true
         @selected_option_count = null
 
         if @is_multiple

--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -2,6 +2,7 @@ class SelectParser
 
   constructor: (form_field) ->
     @form_field = form_field
+    @group_offset = 0
 
   add_node: (child) ->
     if child.nodeName.toUpperCase() is "OPTGROUP"
@@ -10,6 +11,7 @@ class SelectParser
       this.add_option child
 
   add_group: (group) ->
+    @group_offset++
     group_position = @parsed.length
     @parsed.push
       array_index: group_position
@@ -25,6 +27,7 @@ class SelectParser
         if group_position?
           @parsed[group_position].children += 1
         item = this.option_to_item option, group_disabled
+        item.group_offset = @group_offset
         item.array_index = @parsed.length
         item.options_index = @options_index
         item.disabled = group_disabled if group_disabled is true


### PR DESCRIPTION
Previously, optgroups contained options whose indices failed to account
for the offsets created by optgroup nodes. The result was that the final
n options of the select drop-down were unselectable, where n = the
number of optgroups used.

This commit fixes that bug.