### PR TITLE
Return correct symbols in params[:term], instead of html entities

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -535,7 +535,7 @@ class Chosen extends AbstractChosen
     @selected_item.addClass("chosen-single-with-deselect")
 
   get_search_text: ->
-    if @search_field.val() is @default_text then "" else $('<div/>').text($.trim(@search_field.val())).html()
+    if @search_field.val() is @default_text then "" else $('<div/>').html($.trim(@search_field.val())).text()
 
   get_selected_items: ->
     val = @form_field_jq.val()


### PR DESCRIPTION
This issue happens when trying to search by "&" symbol, it's been converting to html entity "&amp;" and search isn't working properly.
related PR:https://github.com/coupa/coupa_development/pull/22723
- [x] @johnny-lai 