### PR TITLE
Added disable_browser_check option to bypass the browser_is_supported check if needed for iPhone/Android

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -4,7 +4,7 @@ $.fn.extend({
   chosen: (options) ->
     # Do no harm and return as soon as possible for unsupported browsers, namely IE6 and IE7
     # Continue on if running IE document type but in compatibility mode
-    return this unless AbstractChosen.browser_is_supported()
+    return this unless AbstractChosen.browser_is_supported(options)
     this.each (input_field) ->
       $this = $ this
       chosen = $this.data('chosen')

--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -1,7 +1,7 @@
 class AbstractChosen
 
   constructor: (@form_field, @options={}) ->
-    return unless AbstractChosen.browser_is_supported()
+    return unless AbstractChosen.browser_is_supported(@options)
     @search_count = 0
     @scopes = []
     @scopes_of_selection = []
@@ -290,7 +290,8 @@ class AbstractChosen
 
   # class methods and variables ============================================================ 
 
-  @browser_is_supported: ->
+  @browser_is_supported: (options = {}) ->
+    return true if options.disable_browser_check
     if window.navigator.appName == "Microsoft Internet Explorer"
       if document.documentMode
         # IE 7 does not provide document.documentMode


### PR DESCRIPTION
# Issue
Allow the browser_is_supported check to be disabled for cases where we want to use the jquery.chosen plugin for a URLDataSource and the platform is iPhone/Android

# Solution
Added disable_browser_check option to list of options that can be passed to the plugin so we can continue to use it for iPhone/Android when necessary.